### PR TITLE
--bump up braintree-web-drop-in version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "src"
   ],
   "dependencies": {
-    "braintree-web-drop-in": "^1.22.0",
+    "braintree-web-drop-in": "^1.31.2",
     "core-js": "^3.6.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue on node v16 is fixed on a later version of braintree-web (used by braintree-web-drop-in)  https://gitmemory.cn/repo/braintree/braintree-web/issues/576